### PR TITLE
Enable/Disable based on appsetting

### DIFF
--- a/Devbridge.BasicAuthentication.Test/Web.config
+++ b/Devbridge.BasicAuthentication.Test/Web.config
@@ -7,6 +7,7 @@
     <add key="webpages:Version" value="1.0.0.0"/>
     <add key="ClientValidationEnabled" value="true"/>
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="BasicAuthEnabled" value="tru"/>
   </appSettings>
   <basicAuth configSource="Config\basicAuthentication.config" />
   <system.web>

--- a/Devbridge.BasicAuthentication/BasicAuthenticationModule.cs
+++ b/Devbridge.BasicAuthentication/BasicAuthenticationModule.cs
@@ -62,6 +62,11 @@ namespace Devbridge.BasicAuthentication
         public const string Realm = "demo";
 
         /// <summary>
+        /// The App Setting that can enable/disable the entire functionality
+        /// </summary>
+        public const string EnabledAppSetting = "BasicAuthEnabled";
+
+        /// <summary>
         /// The credentials that are allowed to access the site.
         /// </summary>
         private IDictionary<string, string> activeUsers;
@@ -80,6 +85,11 @@ namespace Devbridge.BasicAuthentication
         /// Regular expression that matches any given string.
         /// </summary>
         private readonly static Regex AllowAnyRegex = new Regex(".*", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Boolean that allows an app setting to enable/disable basic auth
+        /// </summary>
+        private bool isEnabled = true;
 
         /// <summary>
         /// Dictionary that caches whether basic authentication challenge should be sent. Key is request URL + request method, value indicates whether
@@ -147,6 +157,12 @@ namespace Devbridge.BasicAuthentication
         /// </summary>
         private bool ShouldChallenge(HttpContext context)
         {
+            // allow app setting take precedence
+            if (!isEnabled)
+            {
+                return false;
+            }
+
             // first check cache
             var key = string.Concat(context.Request.Path, context.Request.HttpMethod);
             if (shouldChallengeCache.ContainsKey(key))
@@ -231,6 +247,12 @@ namespace Devbridge.BasicAuthentication
         {
             var config = System.Configuration.ConfigurationManager.GetSection("basicAuth");
             var basicAuth = (Configuration.BasicAuthenticationConfigurationSection)config;
+
+            var appSetting = System.Configuration.ConfigurationManager.AppSettings[EnabledAppSetting];
+            if (appSetting != null)
+            {
+                this.isEnabled = appSetting == "true";
+            }
 
             this.allowRedirects = basicAuth.AllowRedirects;
             InitCredentials(basicAuth);


### PR DESCRIPTION
When using Azure and deployment slots we found it was difficult to use the swap slot as the basic auth protection would carry across into the production slot.  Within Azure you can set app settings tied to a particular slot but not do a web transform as it goes across, as far as I'm aware.  This patch hooks into this functionality to allow basic auth in a staging slot but not on the production slot.
